### PR TITLE
feat: rewrite `wordWrap` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ percent-encoding = "2"
 idna = "0.2"
 html-escape = "0.2.11"
 regex = "1.6.0"
+textwrap = "0.15.0"
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 mimalloc-rust = { version = "0.2" }

--- a/__test__/word_wrap.spec.ts
+++ b/__test__/word_wrap.spec.ts
@@ -1,0 +1,29 @@
+import test from 'ava'
+
+import { wordWrap } from '../index'
+
+test('default', (t) => {
+  t.is(wordWrap('Once upon a time'), 'Once upon a time')
+})
+
+test('default width', (t) => {
+  t.is(
+    wordWrap(
+      'Once upon a time, in a kingdom called Far Far Away, a king fell ill, and finding a successor to the throne turned out to be more trouble than anyone could have imagined...',
+    ),
+    'Once upon a time, in a kingdom called Far Far Away, a king fell ill, and finding\na successor to the throne turned out to be more trouble than anyone could have\nimagined...',
+  )
+})
+
+test('width = 8', (t) => {
+  t.is(wordWrap('Once upon a time', { width: 8 }), 'Once\nupon a\ntime')
+})
+
+test('width = 1', (t) => {
+  t.is(wordWrap('Once upon a time', { width: 1 }), 'Once\nupon\na\ntime')
+})
+
+test('arg must be a string', (t) => {
+  // @ts-expect-error
+  t.throws(() => wordWrap())
+})

--- a/benchmark/bench.ts
+++ b/benchmark/bench.ts
@@ -24,6 +24,7 @@ benchStripTags()
   .then(benchUnescapeHtml)
   .then(benchEscapeHtml)
   .then(benchEscapeRegExp)
+  .then(benchStripTags)
   .catch((e) => {
     console.error(e)
   })

--- a/benchmark/word_wrap.ts
+++ b/benchmark/word_wrap.ts
@@ -1,0 +1,24 @@
+import b from 'benny'
+import { wordWrap as hexoWordWrap } from 'hexo-util'
+
+import { wordWrap } from '../index'
+
+const wordWrapFixture =
+  'Once upon a time, in a kingdom called Far Far Away, a king fell ill, and finding a successor to the throne turned out to be more trouble than anyone could have imagined...'
+export async function benchWordWrap() {
+  await b.suite(
+    'Word Wrap',
+    b.add('hexo-util-rs', () => {
+      wordWrap(wordWrapFixture)
+      wordWrap(wordWrapFixture, { width: 8 })
+    }),
+
+    b.add('hexo-util', () => {
+      hexoWordWrap(wordWrapFixture)
+      hexoWordWrap(wordWrapFixture, { width: 8 })
+    }),
+
+    b.cycle(),
+    b.complete(),
+  )
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,3 +16,7 @@ export interface Options {
 export function slugize(str: Buffer | string, options?: Options | undefined | null): string
 export function stripTags(htmlContent: Buffer | string): string
 export function unescapeHtml(input: Buffer | string): string
+export interface WordWrapOptions {
+  width: number
+}
+export function wordWrap(input: string, options?: WordWrapOptions | undefined | null): string

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const {
   slugize,
   stripTags,
   unescapeHtml,
+  wordWrap,
 } = require('./utils')
 
 const externalLinkCache = new Cache()
@@ -38,3 +39,4 @@ module.exports.escapeRegExp = escapeRegExp
 module.exports.slugize = slugize
 module.exports.stripTags = stripTags
 module.exports.unescapeHtml = unescapeHtml
+module.exports.wordWrap = wordWrap

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,4 @@ mod slugize;
 mod strip_html;
 mod traits;
 mod unescape_html;
+mod word_wrap;

--- a/src/word_wrap.rs
+++ b/src/word_wrap.rs
@@ -1,0 +1,12 @@
+use napi::bindgen_prelude::*;
+
+#[napi(object)]
+pub struct WordWrapOptions {
+  pub width: u32,
+}
+
+#[napi(strict)]
+pub fn word_wrap(input: String, options: Option<WordWrapOptions>) -> Result<String> {
+  let width = options.map(|options| options.width).unwrap_or(80);
+  Ok(textwrap::fill(&input, width as usize))
+}

--- a/utils.js
+++ b/utils.js
@@ -225,9 +225,10 @@ const {
   escapeHtml,
   escapeRegExp,
   isExternalLink,
-  unescapeHtml,
   slugize,
   stripTags,
+  unescapeHtml,
+  wordWrap,
 } = nativeBinding
 
 module.exports.decodeUrl = decodeUrl
@@ -239,3 +240,4 @@ module.exports.isExternalLink = isExternalLink
 module.exports.slugize = slugize
 module.exports.stripTags = stripTags
 module.exports.unescapeHtml = unescapeHtml
+module.exports.wordWrap = wordWrap


### PR DESCRIPTION
😮‍💨😮‍💨😮‍💨
```
yarn bench
Running "Word Wrap" suite...
Progress: 50%

  hexo-util-rs:
    46 864 ops/s, ±0.87% 
Progress: 100%

  hexo-util-rs:
    46 864 ops/s, ±0.87%    | slowest, 79.49% slower

  hexo-util:
    228 459 ops/s, ±1.77%   | fastest

Finished 2 cases!
  Fastest: hexo-util
  Slowest: hexo-util-rs
```